### PR TITLE
exit with error code

### DIFF
--- a/dereference.js
+++ b/dereference.js
@@ -33,6 +33,7 @@ function replacer(key, value) {
 parser.dereference(input, { resolve: { s3: s3Resolver } }, function(err, schema) {
   if (err) {
     console.error(err.message);
+    process.exit(1);
   } else {
     //console.log("Refs:");
     //console.log(parser.$refs);

--- a/dereference.js
+++ b/dereference.js
@@ -32,14 +32,14 @@ function replacer(key, value) {
 
 parser.dereference(input, { resolve: { s3: s3Resolver } }, function(err, schema) {
   if (err) {
-    console.error(err);
+    console.error(err.message);
   } else {
     //console.log("Refs:");
     //console.log(parser.$refs);
 
     var output = path.resolve(argv.o);
     var ext = path.parse(output).ext;
-    
+
     if (ext == '.json') {
       var data = JSON.stringify(schema, null, 4);
       fs.writeFileSync(output, data, { encoding: 'utf8', flag: 'w' });


### PR DESCRIPTION
I use json-dereference-cli for CI/CD jobs and i want to let the job fail if dereferencing fails.

I added an exit in error cases. 

I changed the error output to just the message. This does not overload the job output.